### PR TITLE
Fix multilanguage sitemap generation issue

### DIFF
--- a/models/sitemap.py
+++ b/models/sitemap.py
@@ -19,7 +19,7 @@ class Sitemap(osv.osv):
         sitemap_model = request.env['website_sitemap.extended']
 
         for page in pages:
-            sitemap_info = sitemap_model.search([('location', '=', page['loc'])])
+            sitemap_info = sitemap_model.search([('location', '=', page['loc'])], limit=1)
 
             if not sitemap_info:
                 sitemap_model.sudo().create({


### PR DESCRIPTION
When checking if a location exists, limit the search results to 1, to avoid "ValueError - Expected Singleton" in models/sitemap.py:30. The possibility of multiple search results seems to occur at least on multilanguage sites.  